### PR TITLE
Create a Python package with service manager

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,28 @@
+import setuptools
+
+with open("README.md", "r") as fh:
+    long_description = fh.read()
+
+setuptools.setup(
+    name="yapapi-service-manager",
+    version="0.0.0",
+    author="Golem Factory, Jan Betley",
+    author_email="contact@golem.network, jan.betley@golem.network",
+    description="Helper tool for management of Golem-based services",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://handbook.golem.network/yapapi/",
+    download_url="https://github.com/golemfactory/yapapi-service-manager",
+    packages=setuptools.find_packages(),
+    install_requires=["yapapi==0.6.0",],
+    classifiers=[
+        "Development Status :: 0 - Alpha",
+        "Framework :: YaPaPI",
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)",
+        "Operating System :: OS Independent",
+        "Topic :: Software Development :: Libraries :: Python Modules",
+        "Topic :: System :: Distributed Computing",
+    ],
+    python_requires=">=3.6.1",
+)


### PR DESCRIPTION
This PR resolves following JIRA ticket

<!-- Link you JIRA ticket below--> 
- [APPS-156](https://golemproject.atlassian.net/browse/APPS-156)
- After closing remember to delete also the _test branch:_ (`pnowosie/allow-pip-installation-from-github-test`)
<!-- IMPORTANT: If the changes resolves only part of the task - explain here which part and point to other related PRs 
-->

## Description

<!-- 
DON'T JUST COPY following WHY & WHAT out of JIRA ticket!
Check first if it relates to what this PR delivers
-->

### Why
- We need a way to install and import the library.

### What
- Add any necessary configs to make it a python package.
- Developer should be able to install it via pip by providing a GitHub link.


## Testing instructions

### Assumptions 

- Service Manager source code is present in the same directory as `setup.py` file.

### How to test

- We can install the package directly from GH branch I made for test [branch pip-installation-from-github](https://github.com/golemfactory/yapapi-service-manager/tree/pnowosie/allow-pip-installation-from-github-test)
- Activate new python venv
- execute `pip install git+https://github.com/golemfactory/yapapi-service-manager.git@pnowosie/allow-pip-installation-from-github-test`

The result:
```
Collecting git+https://github.com/golemfactory/yapapi-service-manager.git@pnowosie/allow-pip-installation-from-github-test
  Cloning https://github.com/golemfactory/yapapi-service-manager.git (to revision pnowosie/allow-pip-installation-from-github-test) to /private/var/folders/0b/5h7jts757tgd84lg7gl_6w7c0000gn/T/pip-req-build-exnxf3qy
Collecting yapapi==0.6.0
  Downloading yapapi-0.6.0-py3-none-any.whl (82 kB)
     |████████████████████████████████| 82 kB 917 kB/s
Collecting ya-aioclient<0.6.0,>=0.5.0
  Using cached ya_aioclient-0.5.0-py3-none-any.whl (429 kB)
Collecting colorama<0.5.0,>=0.4.4
  Using cached colorama-0.4.4-py2.py3-none-any.whl (16 kB)
Collecting more-itertools<9.0.0,>=8.6.0
  Downloading more_itertools-8.8.0-py3-none-any.whl (48 kB)
     |████████████████████████████████| 48 kB 1.6 MB/s
Collecting aiohttp<4.0,>=3.6
  Using cached aiohttp-3.7.4.post0.tar.gz (1.1 MB)
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
    Preparing wheel metadata ... done
Collecting urllib3<2.0.0,>=1.25.9
  Using cached urllib3-1.26.5-py2.py3-none-any.whl (138 kB)
Collecting jsonrpc-base<2.0.0,>=1.0.3
  Using cached jsonrpc-base-1.1.0.tar.gz (5.5 kB)
Collecting python-statemachine<0.9.0,>=0.8.0
  Downloading python_statemachine-0.8.0-py2.py3-none-any.whl (12 kB)

...
    Running setup.py install for jsonrpc-base ... done
    Running setup.py install for wrapt ... done
    Running setup.py install for yapapi-service-manager ... done
Successfully installed Deprecated-1.2.12 aiohttp-3.7.4.post0 aiohttp-sse-client-0.1.7 async-exit-stack-1.0.1 async-timeout-3.0.1 attrs-21.2.0 certifi-2020.12.5 chardet-4.0.0 colorama-0.4.4 dnspython-2.1.0 idna-3.2 jsonrpc-base-1.1.0 more-itertools-8.8.0 multidict-5.1.0 python-dateutil-2.8.1 python-statemachine-0.8.0 six-1.16.0 srvresolver-0.3.5 toml-0.10.2 typing-extensions-3.10.0.0 urllib3-1.26.5 wrapt-1.12.1 ya-aioclient-0.5.0 yapapi-0.6.0 yapapi-service-manager-0.0.0 yarl-1.6.3
```

<!-- FILL FREE TO ADD OTHER SECTIONS IF NEEDED -->
