### PR TITLE
Exception in get_payload is not ignored

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -12,4 +12,4 @@ disable=missing-docstring,
 [FORMAT]
 
 max-line-length=120
-good-names=i,e,id
+good-names=i,e,id,f


### PR DESCRIPTION
More general, no exception when starting a service will ever be ignored.

Fixes #8.

This PR resolves following JIRA ticket

<!-- Link you JIRA ticket below--> 
- [APPS-229](https://golemproject.atlassian.net/browse/APPS-229)
<!--
IMPORTANT: If the changes resolves only part of the task - explain here which part and point to other related PRs 
-->

## Description

In the current master if there is an exception when the service is being initialized, it doesn't appear in the logs and everything behaves as if there were no providers available.
In this PR the exception is handled with the same handler that handles all other yapapi-related exceptions.

## Testing instructions

Examples should work.
Exception in `get_payload` method should stop the execution.