### PR TITLE
Latest yapapi

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -12,4 +12,4 @@ disable=missing-docstring,
 [FORMAT]
 
 max-line-length=120
-good-names=i,e,id,f
+good-names=i,e,id,f,ip

--- a/README.md
+++ b/README.md
@@ -89,12 +89,18 @@ service_wrapper = service_manager.create_service(
     # Factory function returning instance of yapapi_service_manager.ServiceWrapper
     # Sample usage --> Erigon example
     service_wrapper_factory=yapapi_service_manager.ServiceWrapper,
+
+    # Attach service to this network (object created by service_wrapper.create_network)
+    # NOTE: service_cls.payload() should require a VPN capability for this to work
+    network=network
 )
 
 service_wrapper.stop()   # Stop the service. This terminates the agreement.
 service_wrapper.status   # pending -> starting -> running -> stopping -> stopped
                          # (also possible-but-not-expected: unresponsive and failed)
 service_wrapper.service  # Instance of service_cls
+
+await service_wrapper.create_network(ip, **kwargs)  # redirects to `yapapi.Golem.create_network`
 
 await service_manager.close()  # Close the Executor, stop all Golem-related work
 ```

--- a/README.md
+++ b/README.md
@@ -81,10 +81,6 @@ service_manager = ServiceManager(
 service_wrapper = service_manager.create_service(
     # Service implementation, class inheriting from yapapi.services.Service
     service_cls,
-    
-    # Arguments that will be passed to the runtime start.
-    # This currenly makes sense only for custom runtimes --> Erigon example
-    start_args=[],
 
     # Factory function returning instance of yapapi_service_manager.ServiceWrapper
     # Sample usage --> Erigon example

--- a/README.md
+++ b/README.md
@@ -89,10 +89,11 @@ service_wrapper = service_manager.create_service(
     # Factory function returning instance of yapapi_service_manager.ServiceWrapper
     # Sample usage --> Erigon example
     service_wrapper_factory=yapapi_service_manager.ServiceWrapper,
-
-    # Attach service to this network (object created by service_wrapper.create_network)
-    # NOTE: service_cls.payload() should require a VPN capability for this to work
-    network=network
+    
+    # Optional dictionary of parameters passed directly to Golem.run_service
+    # (e.g. network or instance_params). IMPORTANT NOTE: some params might influence the number
+    # of instances created. This must be avoided, exactly one instance should be always created.
+    run_service_params=None,
 )
 
 service_wrapper.stop()   # Stop the service. This terminates the agreement.

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ service_wrapper.status   # pending -> starting -> running -> stopping -> stopped
                          # (also possible-but-not-expected: unresponsive and failed)
 service_wrapper.service  # Instance of service_cls
 
-await service_wrapper.create_network(ip, **kwargs)  # redirects to `yapapi.Golem.create_network`
+await service_manager.create_network(ip, **kwargs)  # redirects to `yapapi.Golem.create_network`
 
 await service_manager.close()  # Close the Executor, stop all Golem-related work
 ```

--- a/examples/clock.py
+++ b/examples/clock.py
@@ -22,17 +22,14 @@ class ProviderClock(Service):
         while True:
             #   Q: If we want the datetime, why not just use standard datetime library?
             #   A: Because this python code is running on the **requestor** machine. To execute anything on the
-            #      provider, we need self._ctx.run(). That's a really important distinction.
-            self._ctx.run('/bin/date')
-            future_result = yield self._ctx.commit()
-            all_results = future_result.result()
+            #      provider, we need script.run(). That's a really important distinction.
+            script = self._ctx.new_script()
+            run_date = script.run('/bin/date')
+            yield script
 
-            #   all_results might contain also results of deploy() and start() operations (for the first iteration)
-            #   but this particular operation is always last
-            this_result = all_results[-1]
-            date_time = this_result.stdout.strip()
-
+            date_time = run_date.result().stdout.strip()
             print(f"My name is {self.provider_name} and my time is {date_time}")
+
             self.command_executed_cnt += 1
             await asyncio.sleep(1)
 
@@ -56,7 +53,7 @@ async def run_service(service_manager):
 
 def main():
     executor_cfg = {
-        'subnet_tag': 'devnet-beta.2',
+        'subnet_tag': 'devnet-beta',
         'budget': 1,
     }
     service_manager = ServiceManager(executor_cfg)

--- a/examples/python_shell.py
+++ b/examples/python_shell.py
@@ -17,6 +17,8 @@ class PythonShell(Service):
         return await vm.repo(image_hash=image_hash)
 
     async def start(self):
+        async for script in super().start():
+            yield script
         print(f"Initializing shell on provider {self.provider_name}, wait for prompt ...")
         self._ctx.run('/bin/sh', '-c', 'nohup python shell.py run &')
         yield self._ctx.commit()

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setuptools.setup(
     download_url="https://github.com/golemfactory/yapapi-service-manager",
     packages=setuptools.find_packages(),
     package_data={'yapapi_service_manager': ['py.typed']},
-    install_requires=["yapapi==0.6.2"],
+    install_requires=["yapapi @ git+ssh://git@github.com/golemfactory/yapapi.git"],
     classifiers=[
         "Development Status :: 0 - Alpha",
         "Framework :: YaPaPI",

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setuptools.setup(
     download_url="https://github.com/golemfactory/yapapi-service-manager",
     packages=setuptools.find_packages(),
     package_data={'yapapi_service_manager': ['py.typed']},
-    install_requires=["yapapi @ git+ssh://git@github.com/golemfactory/yapapi.git"],
+    install_requires=["yapapi @ git+https://git@github.com/golemfactory/yapapi.git@b0.7"],
     classifiers=[
         "Development Status :: 0 - Alpha",
         "Framework :: YaPaPI",

--- a/yapapi_service_manager/service_manager.py
+++ b/yapapi_service_manager/service_manager.py
@@ -8,7 +8,7 @@ from .service_wrapper import ServiceWrapper
 from .yapapi_connector import YapapiConnector
 
 if TYPE_CHECKING:
-    from typing import Type, List, Tuple, Callable, Awaitable, Any, Optional
+    from typing import Type, List, Callable, Awaitable, Any, Optional
     from yapapi.services import Service
 
 
@@ -35,11 +35,10 @@ class ServiceManager:
     def create_service(
         self,
         service_cls: 'Type[Service]',
-        start_args: 'Tuple' = (),
-        service_wrapper_factory: 'Callable[[Type[Service], Tuple], ServiceWrapper]' = ServiceWrapper,
+        service_wrapper_factory: 'Callable[[Type[Service]], ServiceWrapper]' = ServiceWrapper,
         run_service_params: 'Optional[dict]' = None,
     ) -> ServiceWrapper:
-        service_wrapper = service_wrapper_factory(service_cls, start_args)
+        service_wrapper = service_wrapper_factory(service_cls)
         if run_service_params is not None:
             service_wrapper.run_service_params = run_service_params
         self.yapapi_connector.create_instance(service_wrapper)

--- a/yapapi_service_manager/service_manager.py
+++ b/yapapi_service_manager/service_manager.py
@@ -10,7 +10,6 @@ from .yapapi_connector import YapapiConnector
 if TYPE_CHECKING:
     from typing import Type, List, Tuple, Callable, Awaitable, Any, Optional
     from yapapi.services import Service
-    from yapapi.network import Network
 
 
 async def stop_on_golem_exception(_service_manager: 'ServiceManager', e: Exception) -> None:
@@ -38,10 +37,11 @@ class ServiceManager:
         service_cls: 'Type[Service]',
         start_args: 'Tuple' = (),
         service_wrapper_factory: 'Callable[[Type[Service], Tuple], ServiceWrapper]' = ServiceWrapper,
-        network: 'Optional[Network]' = None
+        run_service_params: 'Optional[dict]' = None,
     ) -> ServiceWrapper:
         service_wrapper = service_wrapper_factory(service_cls, start_args)
-        service_wrapper.network = network
+        if run_service_params is not None:
+            service_wrapper.run_service_params = run_service_params
         self.yapapi_connector.create_instance(service_wrapper)
         self.service_wrappers.append(service_wrapper)
         return service_wrapper

--- a/yapapi_service_manager/service_wrapper.py
+++ b/yapapi_service_manager/service_wrapper.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from typing import Type, Tuple, Optional
     from yapapi.services import Service, Cluster
+    from yapapi.network import Network
 
 
 class ServiceWrapper:
@@ -13,6 +14,7 @@ class ServiceWrapper:
         self.id = self._create_id()
         self.stopped = False
         self._cluster: 'Optional[Cluster]' = None
+        self.network: 'Optional[Network]' = None
 
     @property
     def status(self):

--- a/yapapi_service_manager/service_wrapper.py
+++ b/yapapi_service_manager/service_wrapper.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from typing import Type, Tuple, Optional
     from yapapi.services import Service, Cluster
-    from yapapi.network import Network
 
 
 class ServiceWrapper:
@@ -14,7 +13,7 @@ class ServiceWrapper:
         self.id = self._create_id()
         self.stopped = False
         self._cluster: 'Optional[Cluster]' = None
-        self.network: 'Optional[Network]' = None
+        self.run_service_params: dict = {}
 
     @property
     def status(self):

--- a/yapapi_service_manager/service_wrapper.py
+++ b/yapapi_service_manager/service_wrapper.py
@@ -2,14 +2,13 @@ import uuid
 
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
-    from typing import Type, Tuple, Optional
+    from typing import Type, Optional
     from yapapi.services import Service, Cluster
 
 
 class ServiceWrapper:
-    def __init__(self, service_cls: 'Type[Service]', start_args: 'Tuple'):
+    def __init__(self, service_cls: 'Type[Service]'):
         self.service_cls = service_cls
-        self.start_args = start_args
         self.id = self._create_id()
         self.stopped = False
         self._cluster: 'Optional[Cluster]' = None

--- a/yapapi_service_manager/yapapi_connector.py
+++ b/yapapi_service_manager/yapapi_connector.py
@@ -45,6 +45,7 @@ class YapapiConnector:
         await self.golem.start()
         cluster = await self.golem.run_service(
             service_wrapper.service_cls,
+            num_instances=1,
             **service_wrapper.run_service_params,
         )
 

--- a/yapapi_service_manager/yapapi_connector.py
+++ b/yapapi_service_manager/yapapi_connector.py
@@ -26,7 +26,7 @@ class YapapiConnector:
         self.run_service_tasks: 'List[asyncio.Task]' = []
 
     def create_instance(self, service_wrapper: 'ServiceWrapper'):
-        run_service = asyncio.create_task(self.run_service(service_wrapper))
+        run_service = asyncio.get_event_loop().create_task(self.run_service(service_wrapper))
         self.run_service_tasks.append(run_service)
 
     async def stop(self):

--- a/yapapi_service_manager/yapapi_connector.py
+++ b/yapapi_service_manager/yapapi_connector.py
@@ -79,7 +79,7 @@ class YapapiConnector:
     async def _run_service(self, golem: Golem, service_wrapper: 'ServiceWrapper'):
         cluster = await golem.run_service(
             service_wrapper.service_cls,
-            network=service_wrapper.network
+            **service_wrapper.run_service_params,
         )
 
         #   TODO: this will change when yapapi issue 372 is fixed

--- a/yapapi_service_manager/yapapi_connector.py
+++ b/yapapi_service_manager/yapapi_connector.py
@@ -49,12 +49,4 @@ class YapapiConnector:
             **service_wrapper.run_service_params,
         )
 
-        #   TODO: https://github.com/golemfactory/yapapi-service-manager/issues/15
-        cluster.instance_start_args = service_wrapper.start_args  # type: ignore
-
-        #   TODO: this will be removed when yapapi issue 461 is fixed
-        #         (currently the cluster is "fully operable" only after all instances started)
-        while not cluster.instances:
-            await asyncio.sleep(0.1)
-
         service_wrapper.cluster = cluster


### PR DESCRIPTION
CHANGES
1. latest `yapapi` master in requirements
1. new `service_manager.create_network` method
2. `run_service_params` passed to `create_service`
3. `golem.start()` and `golem.stop()` in `yapapi_connector` --> a lot of junk removed
4. `python-shell` example now works with new yapapi

NOT DONE:
#15 and #16 will be done later in separate PRs

GENERAL NOTES
* Some things could be prettier, but this is a library we hope to abandon one day.
* CI checks are failing & I don't know why
* I think I will merge this only **after** `yapapi` is released --> there will be no github in requirements -> maybe checks will work?

ref https://github.com/golemfactory/ya-httpx-client/issues/10